### PR TITLE
corrected SessionTrainingStatus to not return 'trained' when a single…

### DIFF
--- a/ibl_pipeline/analyses/behavior.py
+++ b/ibl_pipeline/analyses/behavior.py
@@ -370,9 +370,12 @@ class SessionTrainingStatus(dj.Computed):
             )
         status = previous_sessions.fetch('training_status')
 
+        # ================================= #
         # if the protocol for the current session is a biased session,
         # set the status to be "trained" and check up the criteria for
-        # "read for ephys"
+        # "ready for ephys"
+        # ================================= #
+
         task_protocol = (acquisition.Session & key).fetch1('task_protocol')
         if task_protocol and 'biased' in task_protocol:
             if not(len(status) and np.any(status == 'trained')):
@@ -380,13 +383,13 @@ class SessionTrainingStatus(dj.Computed):
                 self.insert1(key)
                 return
 
+            # if the animal previously reached 'ready for ephys', keep
             elif len(status) and np.any(status == 'ready for ephys'):
                 key['training_status'] = 'ready for ephys'
                 self.insert1(key)
                 return
 
-            key['training_status'] = 'trained'
-
+            # key['training_status'] = 'trained'
             # Criteria for "ready for ephys" status
             sessions = (behavior.TrialSet & subject_key &
                         (acquisition.Session & 'task_protocol LIKE "%biased%"') &
@@ -394,54 +397,58 @@ class SessionTrainingStatus(dj.Computed):
                             key['session_start_time'].strftime(
                                 '%Y-%m-%d %H:%M:%S')
                             )).fetch('KEY')
-            # if not more than 3 biased sessions, keep status trained
-            if len(sessions) < 3:
-                self.insert1(key)
-                return
 
-            sessions_rel = sessions[-3:]
-            n_trials = (behavior.TrialSet & sessions_rel).fetch('n_trials')
-            performance_easy = (PsychResults & sessions_rel).fetch(
-                'performance_easy')
-            if np.all(n_trials > 200) and np.all(performance_easy > 0.8):
-                trials = behavior.TrialSet.Trial & sessions_rel
-                prob_lefts = (dj.U('trial_stim_prob_left') & trials).fetch(
-                    'trial_stim_prob_left')
+            # if not more than 3 biased sessions, continue 
+            if len(sessions) >= 3:
+                    # self.insert1(key)
+                    # return
 
-                # if no 0.5 of prob_left, keep trained
-                if np.all(abs(prob_lefts - 0.5) > 0.001):
-                    self.insert1(key)
-                    return
+                sessions_rel = sessions[-3:]
+                n_trials = (behavior.TrialSet & sessions_rel).fetch('n_trials')
+                performance_easy = (PsychResults & sessions_rel).fetch(
+                    'performance_easy')
+                if np.all(n_trials > 200) and np.all(performance_easy > 0.8):
+                    trials = behavior.TrialSet.Trial & sessions_rel
+                    prob_lefts = (dj.U('trial_stim_prob_left') & trials).fetch(
+                        'trial_stim_prob_left')
 
-                trials_unbiased = trials & \
-                    'ABS(trial_stim_prob_left - 0.5) < 0.001'
+                    # check if there are biased blocks present in these 3 sessions
+                    if not np.all(abs(prob_lefts - 0.5) > 0.001):
+                            # self.insert1(key)
+                            # return
 
-                trials_80 = trials & \
-                    'ABS(trial_stim_prob_left - 0.2) < 0.001'
+                        trials_unbiased = trials & \
+                            'ABS(trial_stim_prob_left - 0.5) < 0.001'
 
-                trials_20 = trials & \
-                    'ABS(trial_stim_prob_left - 0.8) < 0.001'
+                        trials_80 = trials & \
+                            'ABS(trial_stim_prob_left - 0.2) < 0.001'
 
-                psych_unbiased = utils.compute_psych_pars(trials_unbiased)
-                psych_80 = utils.compute_psych_pars(trials_80)
-                psych_20 = utils.compute_psych_pars(trials_20)
+                        trials_20 = trials & \
+                            'ABS(trial_stim_prob_left - 0.8) < 0.001'
 
-                criterion = abs(psych_unbiased['bias']) < 16 and \
-                    psych_unbiased['threshold'] < 19 and \
-                    psych_unbiased['lapse_low'] < 0.2 and \
-                    psych_unbiased['lapse_high'] < 0.2 and \
-                    psych_20['bias'] - psych_80['bias'] > 5
+                        psych_unbiased = utils.compute_psych_pars(trials_unbiased)
+                        psych_80 = utils.compute_psych_pars(trials_80)
+                        psych_20 = utils.compute_psych_pars(trials_20)
 
-                if criterion:
-                    key['training_status'] = 'ready for ephys'
+                        criterion = abs(psych_unbiased['bias']) < 16 and \
+                            psych_unbiased['threshold'] < 19 and \
+                            psych_unbiased['lapse_low'] < 0.2 and \
+                            psych_unbiased['lapse_high'] < 0.2 and \
+                            psych_20['bias'] - psych_80['bias'] > 5
 
-            self.insert1(key)
-            return
+                        # if 'ready for ephys' is met, mark and return
+                        if criterion:
+                            key['training_status'] = 'ready for ephys'
+                            self.insert1(key)
+                            return
 
         # if the current session is not a biased session
-        key['training_status'] = 'training in progress'
+        # key['training_status'] = 'training in progress'
 
-        # if has reached 'trained' before, mark the current session 'trained as well'
+        # ================================= #
+        # if has reached 'trained' before, mark the current session 'trained' as well
+        # ================================= #
+
         if len(status) and np.any(status == 'trained'):
             key['training_status'] = 'trained'
             self.insert1(key)
@@ -452,60 +459,70 @@ class SessionTrainingStatus(dj.Computed):
                     'session_start_time <= "{}"'.format(
                         key['session_start_time'].strftime('%Y-%m-%d %H:%M:%S')
                         )).fetch('KEY')
-        if len(sessions) < 3:
-            self.insert1(key)
-            return
 
-        # training in progress if any of the last three sessions have
-        # < 200 trials or performance of easy trials < 0.8
-        sessions_rel = sessions[-3:]
-        n_trials = (behavior.TrialSet & sessions_rel).fetch('n_trials')
-        performance_easy = (PsychResults & sessions_rel).fetch(
-            'performance_easy')
+        # ================================= #
+        # if the animal did more than 3 sessions,
+        # check if it may be considered 'trained'
+        # ================================= #
 
-        if np.all(n_trials > 200) and np.all(performance_easy > 0.8):
-            # training in progress if the current session does not
-            # have low contrasts
-            contrasts = abs(
-                (PsychResults & key).fetch1('signed_contrasts'))
-            if 0 in contrasts and \
-               np.sum((contrasts < 0.065) & (contrasts > 0.001)):
-                # compute psych results of last three sessions
-                trials = behavior.TrialSet.Trial & sessions_rel
-                psych = utils.compute_psych_pars(trials)
-                cum_perform_easy = utils.compute_performance_easy(trials)
+        if len(sessions) >= 3:
+            # self.insert1(key)
+            # return
 
-                criterion = abs(psych['bias']) < 16 and \
-                    psych['threshold'] < 19 and \
-                    psych['lapse_low'] < 0.2 and \
-                    psych['lapse_high'] < 0.2
+            # training in progress if any of the last three sessions have
+            # < 200 trials or performance of easy trials < 0.8
+            sessions_rel = sessions[-3:]
+            n_trials = (behavior.TrialSet & sessions_rel).fetch('n_trials')
+            performance_easy = (PsychResults & sessions_rel).fetch(
+                'performance_easy')
 
-                if criterion:
-                    key['training_status'] = 'trained'
-                    self.insert1(key)
-                    # insert computed results into the part table
-                    n_trials, n_correct_trials = \
-                        (behavior.TrialSet & key).fetch(
-                            'n_trials', 'n_correct_trials')
-                    cum_psych_results.update({
-                        'cum_performance': np.divide(
-                            np.sum(n_correct_trials),
-                            np.sum(n_trials)),
-                        'cum_performance_easy': cum_perform_easy,
-                        'cum_signed_contrasts': psych['signed_contrasts'],
-                        'cum_n_trials_stim': psych['n_trials_stim'],
-                        'cum_n_trials_stim_right': psych[
-                            'n_trials_stim_right'],
-                        'cum_prob_choose_right': psych['prob_choose_right'],
-                        'cum_bias': psych['bias'],
-                        'cum_threshold': psych['threshold'],
-                        'cum_lapse_low': psych['lapse_low'],
-                        'cum_lapse_high': psych['lapse_high']
-                    })
-                    self.CumulativePsychResults.insert1(cum_psych_results)
-                    return
+            if np.all(n_trials > 200) and np.all(performance_easy > 0.8):
+                # training in progress if the current session does not
+                # have low contrasts
+                contrasts = abs(
+                    (PsychResults & key).fetch1('signed_contrasts'))
+                if 0 in contrasts and \
+                   np.sum((contrasts < 0.065) & (contrasts > 0.001)):
+                    # compute psych results of last three sessions
+                    trials = behavior.TrialSet.Trial & sessions_rel
+                    psych = utils.compute_psych_pars(trials)
+                    cum_perform_easy = utils.compute_performance_easy(trials)
 
-        # check whether the subject has been trained over 40 days.
+                    criterion = abs(psych['bias']) < 16 and \
+                        psych['threshold'] < 19 and \
+                        psych['lapse_low'] < 0.2 and \
+                        psych['lapse_high'] < 0.2
+
+                    if criterion:
+                        key['training_status'] = 'trained'
+                        self.insert1(key)
+                        # insert computed results into the part table
+                        n_trials, n_correct_trials = \
+                            (behavior.TrialSet & key).fetch(
+                                'n_trials', 'n_correct_trials')
+                        cum_psych_results.update({
+                            'cum_performance': np.divide(
+                                np.sum(n_correct_trials),
+                                np.sum(n_trials)),
+                            'cum_performance_easy': cum_perform_easy,
+                            'cum_signed_contrasts': psych['signed_contrasts'],
+                            'cum_n_trials_stim': psych['n_trials_stim'],
+                            'cum_n_trials_stim_right': psych[
+                                'n_trials_stim_right'],
+                            'cum_prob_choose_right': psych['prob_choose_right'],
+                            'cum_bias': psych['bias'],
+                            'cum_threshold': psych['threshold'],
+                            'cum_lapse_low': psych['lapse_low'],
+                            'cum_lapse_high': psych['lapse_high']
+                        })
+                        self.CumulativePsychResults.insert1(cum_psych_results)
+                        return
+
+        # ================================= #
+        # if none of the previous criteria has been met,
+        # check whether the subject has been trained over 40 days
+        # ================================= #
+
         if len(sessions) >= 40:
             key['training_status'] = 'over40days'
 


### PR DESCRIPTION
… biasedChoiceWorld session is run

* added some comments to clarify the steps in the SessionTrainingStatus schema
* when <3 sessions are present, do *not* just assume the previous status but continue checking